### PR TITLE
Add tests to verify order guarantees

### DIFF
--- a/test/DotNet.Collections.Tests/ConcurrentOrderedMap.cs
+++ b/test/DotNet.Collections.Tests/ConcurrentOrderedMap.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace DotNet.Collections.Tests
@@ -138,6 +139,87 @@ namespace DotNet.Collections.Tests
         {
             var dict = new ConcurrentOrderedDictionary<string, string>();
             Assert.False(dict.TryGetValue("foo", out var value));
+        }
+
+        [Fact]
+        public void ConcurrentOrderedMap_ByDefault_OrdersKeys_ByInsertionOrder()
+        {
+            const string firstKey = "foo";
+            const string secondKey = "bar";
+
+            var dict = new ConcurrentOrderedDictionary<string, string>();
+            dict.Add(firstKey, "bar");
+            dict.Add(secondKey, "foo");
+
+            var expectedOrder = new[] { firstKey, secondKey };
+            Assert.Equal(expectedOrder, dict.Keys);
+        }
+
+        [Fact]
+        public void ConcurrentOrderedMap_ByDefault_OrdersValues_ByInsertionOrder()
+        {
+            const string firstValue = "foo";
+            const string secondValue = "bar";
+
+            var dict = new ConcurrentOrderedDictionary<string, string>();
+            dict.Add("foo", firstValue);
+            dict.Add("bar", secondValue);
+
+            var expectedOrder = new[] { firstValue, secondValue };
+            Assert.Equal(expectedOrder, dict.Values);
+        }
+
+        [Fact]
+        public void ConcurrentOrderedMap_ByDefault_EnumeratesValues_ByInsertionOrder()
+        {
+            const string firstValue = "foo";
+            const string secondValue = "bar";
+
+            var dict = new ConcurrentOrderedDictionary<string, string>();
+            dict.Add("foo", firstValue);
+            dict.Add("bar", secondValue);
+
+            using (IEnumerator<string> enumerator = dict.GetEnumerator())
+            {
+                enumerator.MoveNext();
+                Assert.Equal(firstValue, enumerator.Current);
+                enumerator.MoveNext();
+                Assert.Equal(secondValue, enumerator.Current);
+            }
+        }
+
+        [Fact]
+        public void ConcurrentOrderedMap_ByDefault_CopiesTo_ByInsertionOrder()
+        {
+            IEnumerable<string> expectedValues = Enumerable.Range(0, 10).Reverse().Select(v => v.ToString());
+
+            var dict = new ConcurrentOrderedDictionary<string, string>();
+            foreach (var val in expectedValues)
+            {
+                dict.Add(val, val);
+            }
+
+            var copiedArray = new string[10];
+            dict.CopyTo(copiedArray, 0);
+
+            Assert.Equal(expectedValues, copiedArray);
+        }
+
+        [Fact]
+        public void ConcurrentOrderedMap_ByDefault_CopiesTo_ByInsertionOrder_AndRespectsArrayIndex()
+        {
+            IEnumerable<string> expectedValues = Enumerable.Range(0, 10).Reverse().Select(v => v.ToString());
+
+            var dict = new ConcurrentOrderedDictionary<string, string>();
+            foreach (var val in expectedValues)
+            {
+                dict.Add(val, val);
+            }
+
+            var copiedArray = new string[15];
+            dict.CopyTo(copiedArray, 5);
+
+            Assert.Equal(expectedValues, copiedArray.Skip(5));
         }
     }
 }

--- a/test/DotNet.Collections.Tests/ConcurrentOrderedSetTests.cs
+++ b/test/DotNet.Collections.Tests/ConcurrentOrderedSetTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace DotNet.Collections.Tests
@@ -57,6 +59,74 @@ namespace DotNet.Collections.Tests
             var set = new ConcurrentOrderedSet<string>();
 
             Assert.DoesNotContain(item, set);
+        }
+
+        [Fact]
+        public void ConcurrentOrderedSet_OrdersItems_ByInsertionOrder()
+        {
+            const string firstItem = "foo";
+            const string secondItem = "bar";
+
+            var set = new ConcurrentOrderedSet<string>();
+            set.Add(firstItem);
+            set.Add(secondItem);
+
+            var expectedOrder = new[] { firstItem, secondItem };
+            Assert.Equal(expectedOrder, set);
+        }
+
+        [Fact]
+        public void ConcurrentOrderedSet_EnumeratesItems_ByInsertionOrder()
+        {
+            const string firstItem = "foo";
+            const string secondItem = "foo";
+
+            var set = new ConcurrentOrderedSet<string>();
+            set.Add(firstItem);
+            set.Add(secondItem);
+
+            using (IEnumerator<string> enumerator = set.GetEnumerator())
+            {
+                enumerator.MoveNext();
+                Assert.Equal(firstItem, enumerator.Current);
+                enumerator.MoveNext();
+                Assert.Equal(secondItem, enumerator.Current);
+            }
+        }
+
+        [Fact]
+        public void ConcurrentOrderedSet_CopiesTo_ByInsertionOrder()
+        {
+            IEnumerable<string> expectedItems = Enumerable.Range(0, 10).Reverse().Select(v => v.ToString());
+
+            var set = new ConcurrentOrderedSet<string>();
+            foreach (var item in expectedItems)
+            {
+                set.Add(item);
+            }
+
+            var copiedArray = new string[10];
+            set.CopyTo(copiedArray, 0);
+
+            Assert.Equal(expectedItems, copiedArray);
+        }
+
+        [Fact]
+        public void ConcurrentOrderedSet_CopiesTo_ByInsertionOrder_AndRespectsArrayIndex()
+        {
+            IEnumerable<string> expectedItems = Enumerable.Range(0, 10).Reverse().Select(v => v.ToString());
+
+            var set = new ConcurrentOrderedSet<string>();
+            foreach (var item in expectedItems)
+            {
+                set.Add(item);
+            }
+
+            var copiedArray = new string[15];
+            set.CopyTo(copiedArray, 5);
+
+            Assert.Equal(new string[5], copiedArray.Take(5));
+            Assert.Equal(expectedItems, copiedArray.Skip(5));
         }
     }
 }

--- a/test/DotNet.Collections.Tests/OrderedMapTests.cs
+++ b/test/DotNet.Collections.Tests/OrderedMapTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace DotNet.Collections.Tests
@@ -138,6 +139,88 @@ namespace DotNet.Collections.Tests
         {
             var dict = new OrderedDictionary<string, string>();
             Assert.False(dict.TryGetValue("foo", out var value));
+        }
+
+        [Fact]
+        public void OrderedMap_OrdersKeys_ByInsertionOrder()
+        {
+            const string firstKey = "foo";
+            const string secondKey = "bar";
+
+            var dict = new OrderedDictionary<string, string>();
+            dict.Add(firstKey, "bar");
+            dict.Add(secondKey, "foo");
+
+            var expectedOrder = new[] { firstKey, secondKey };
+            Assert.Equal(expectedOrder, dict.Keys);
+        }
+
+        [Fact]
+        public void OrderedMap_OrdersValues_ByInsertionOrder()
+        {
+            const string firstValue = "foo";
+            const string secondValue = "bar";
+
+            var dict = new OrderedDictionary<string, string>();
+            dict.Add("foo", firstValue);
+            dict.Add("bar", secondValue);
+
+            var expectedOrder = new[] { firstValue, secondValue };
+            Assert.Equal(expectedOrder, dict.Values);
+        }
+
+        [Fact]
+        public void OrderedMap_EnumeratesValues_ByInsertionOrder()
+        {
+            const string firstValue = "foo";
+            const string secondValue = "bar";
+
+            var dict = new OrderedDictionary<string, string>();
+            dict.Add("foo", firstValue);
+            dict.Add("bar", secondValue);
+
+            using (IEnumerator<string> enumerator = dict.GetEnumerator())
+            {
+                enumerator.MoveNext();
+                Assert.Equal(firstValue, enumerator.Current);
+                enumerator.MoveNext();
+                Assert.Equal(secondValue, enumerator.Current);
+            }
+        }
+
+        [Fact]
+        public void OrderedMap_CopiesTo_ByInsertionOrder()
+        {
+            IEnumerable<string> expectedValues = Enumerable.Range(0, 10).Reverse().Select(v => v.ToString());
+
+            var dict = new OrderedDictionary<string, string>();
+            foreach (var val in expectedValues)
+            {
+                dict.Add(val, val);
+            }
+
+            var copiedArray = new string[10];
+            dict.CopyTo(copiedArray, 0);
+
+            Assert.Equal(expectedValues, copiedArray);
+        }
+
+        [Fact]
+        public void OrderedMap_CopiesTo_ByInsertionOrder_AndRespectsArrayIndex()
+        {
+            IEnumerable<string> expectedValues = Enumerable.Range(0, 10).Reverse().Select(v => v.ToString());
+
+            var dict = new OrderedDictionary<string, string>();
+            foreach (var val in expectedValues)
+            {
+                dict.Add(val, val);
+            }
+
+            var copiedArray = new string[15];
+            dict.CopyTo(copiedArray, 5);
+
+            Assert.Equal(new string[5], copiedArray.Take(5));
+            Assert.Equal(expectedValues, copiedArray.Skip(5));
         }
     }
 }

--- a/test/DotNet.Collections.Tests/OrderedSetTests.cs
+++ b/test/DotNet.Collections.Tests/OrderedSetTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace DotNet.Collections.Tests
@@ -57,6 +59,74 @@ namespace DotNet.Collections.Tests
             var set = new OrderedSet<string>();
 
             Assert.DoesNotContain(item, set);
+        }
+
+        [Fact]
+        public void OrderedSet_OrdersItems_ByInsertionOrder()
+        {
+            const string firstItem = "foo";
+            const string secondItem = "bar";
+
+            var set = new OrderedSet<string>();
+            set.Add(firstItem);
+            set.Add(secondItem);
+
+            var expectedOrder = new[] { firstItem, secondItem };
+            Assert.Equal(expectedOrder, set);
+        }
+
+        [Fact]
+        public void OrderedSet_EnumeratesItems_ByInsertionOrder()
+        {
+            const string firstItem = "foo";
+            const string secondItem = "foo";
+
+            var set = new OrderedSet<string>();
+            set.Add(firstItem);
+            set.Add(secondItem);
+
+            using (IEnumerator<string> enumerator = set.GetEnumerator())
+            {
+                enumerator.MoveNext();
+                Assert.Equal(firstItem, enumerator.Current);
+                enumerator.MoveNext();
+                Assert.Equal(secondItem, enumerator.Current);
+            }
+        }
+
+        [Fact]
+        public void OrderedSet_CopiesTo_ByInsertionOrder()
+        {
+            IEnumerable<string> expectedItems = Enumerable.Range(0, 10).Reverse().Select(v => v.ToString());
+
+            var set = new OrderedSet<string>();
+            foreach (var item in expectedItems)
+            {
+                set.Add(item);
+            }
+
+            var copiedArray = new string[10];
+            set.CopyTo(copiedArray, 0);
+
+            Assert.Equal(expectedItems, copiedArray);
+        }
+
+        [Fact]
+        public void OrderedSet_CopiesTo_ByInsertionOrder_AndRespectsArrayIndex()
+        {
+            IEnumerable<string> expectedItems = Enumerable.Range(0, 10).Reverse().Select(v => v.ToString());
+
+            var set = new OrderedSet<string>();
+            foreach (var item in expectedItems)
+            {
+                set.Add(item);
+            }
+
+            var copiedArray = new string[15];
+            set.CopyTo(copiedArray, 5);
+
+            Assert.Equal(new string[5], copiedArray.Take(5));
+            Assert.Equal(expectedItems, copiedArray.Skip(5));
         }
     }
 }


### PR DESCRIPTION
I can't seem to find a way to actually make the `KeyValuePair` variants get called (neither the enumerator nor the `CopyTo` method) so I'm open to ideas there as I believe that is the only ordering related piece of functionality these tests do not cover.